### PR TITLE
Add MCP tracking headers to outbound RDC API requests

### DIFF
--- a/src/sauce_api_mcp/rdc_dynamic.py
+++ b/src/sauce_api_mcp/rdc_dynamic.py
@@ -122,10 +122,16 @@ def create_server(
     """Create the FastMCPOpenAPI server with manual tools for binary endpoints."""
     base_url = DATA_CENTERS[region.upper()]
 
+    async def _inject_mcp_headers(request: httpx.Request) -> None:
+        request.headers["X-SAUCE-MCP-SERVER"] = "rdc_dynamic"
+        request.headers["X-SAUCE-MCP-TRANSPORT"] = "stdio"
+        request.headers["X-SAUCE-MCP-USER"] = username
+
     client = httpx.AsyncClient(
         base_url=base_url,
         auth=httpx.BasicAuth(username, access_key),
         params={"ai": "rdc_openapi_mcp"},
+        event_hooks={"request": [_inject_mcp_headers]},
     )
 
     server = FastMCPOpenAPI(

--- a/tests/test_rdc_dynamic_headers.py
+++ b/tests/test_rdc_dynamic_headers.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+from unittest.mock import patch
+
+from sauce_api_mcp.rdc_dynamic import create_server
+
+
+MINIMAL_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "test", "version": "0.0.1"},
+    "paths": {},
+}
+
+
+class TestMcpHeaders:
+    """Verify that outbound requests carry X-SAUCE-MCP-* headers."""
+
+    @pytest.mark.asyncio
+    async def test_inject_mcp_headers(self):
+        # Capture the httpx.AsyncClient instance created inside create_server
+        captured_client = None
+        original_init = httpx.AsyncClient.__init__
+
+        def patched_init(self, *args, **kwargs):
+            nonlocal captured_client
+            original_init(self, *args, **kwargs)
+            captured_client = self
+
+        with patch.object(httpx.AsyncClient, "__init__", patched_init):
+            create_server(
+                spec=MINIMAL_SPEC,
+                access_key="fake_key",
+                username="alice",
+            )
+
+        assert captured_client is not None
+
+        captured_requests: list[httpx.Request] = []
+
+        async def capture_handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={})
+
+        captured_client._transport = httpx.MockTransport(capture_handler)
+
+        await captured_client.get("/test")
+
+        assert len(captured_requests) == 1
+        req = captured_requests[0]
+        assert req.headers["X-SAUCE-MCP-SERVER"] == "rdc_dynamic"
+        assert req.headers["X-SAUCE-MCP-TRANSPORT"] == "stdio"
+        assert req.headers["X-SAUCE-MCP-USER"] == "alice"


### PR DESCRIPTION
## Summary
- Adds `X-SAUCE-MCP-SERVER`, `X-SAUCE-MCP-TRANSPORT`, and `X-SAUCE-MCP-USER` headers to all outbound requests from the `rdc_dynamic` MCP server via an `httpx` request event hook
- The API's existing `Tracing` filter auto-captures any `X-SAUCE-*` header as OTel span attributes — zero API-side changes needed
- Adds unit test verifying the three headers are present with correct values

## Test plan
- [x] Unit test passes (`pytest tests/test_rdc_dynamic_headers.py`)
- [ ] Manual verification: run MCP server, invoke a tool, inspect outbound headers
- [ ] API-side: query OTel spans for `X-SAUCE-MCP-SERVER = rdc_dynamic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)