### PR TITLE
Sanitize file path in upload_file_to_storage

### DIFF
--- a/src/sauce_api_mcp/main.py
+++ b/src/sauce_api_mcp/main.py
@@ -14,26 +14,13 @@ from .models import (
     LookupTeamsResponse,
     ErrorResponse
 )
+from .shared.file_utils import validate_path
 
 DATA_CENTERS = {
     "US_WEST": "https://api.us-west-1.saucelabs.com/",
     "US_EAST": "https://api.us-east-4.saucelabs.com/",
     "EU_CENTRAL": "https://api.eu-central-1.saucelabs.com/",
 }
-
-SAFE_FILE_DIR = os.path.join(os.path.expanduser("~"), ".sauce-mcp", "files")
-
-
-def _validate_path(file_path: str) -> str:
-    """Validate that a file path resolves within SAFE_FILE_DIR."""
-    os.makedirs(SAFE_FILE_DIR, exist_ok=True)
-    resolved = os.path.realpath(os.path.join(SAFE_FILE_DIR, os.path.basename(file_path)))
-    if not resolved.startswith(os.path.realpath(SAFE_FILE_DIR)):
-        raise ValueError(
-            f"Path '{file_path}' resolves outside the safe directory. "
-            f"Files are restricted to {SAFE_FILE_DIR}"
-        )
-    return resolved
 
 logging.basicConfig(
     level=logging.INFO,
@@ -1339,7 +1326,7 @@ class SauceLabsAgent:
                  400	Bad Request.
                  404	Not found.
         """
-        file_path = _validate_path(file_path)
+        file_path = validate_path(file_path)
         if not os.path.exists(file_path):
             raise ValueError(f"File not found: {file_path}")
 

--- a/src/sauce_api_mcp/main.py
+++ b/src/sauce_api_mcp/main.py
@@ -21,6 +21,20 @@ DATA_CENTERS = {
     "EU_CENTRAL": "https://api.eu-central-1.saucelabs.com/",
 }
 
+SAFE_FILE_DIR = os.path.join(os.path.expanduser("~"), ".sauce-mcp", "files")
+
+
+def _validate_path(file_path: str) -> str:
+    """Validate that a file path resolves within SAFE_FILE_DIR."""
+    os.makedirs(SAFE_FILE_DIR, exist_ok=True)
+    resolved = os.path.realpath(os.path.join(SAFE_FILE_DIR, os.path.basename(file_path)))
+    if not resolved.startswith(os.path.realpath(SAFE_FILE_DIR)):
+        raise ValueError(
+            f"Path '{file_path}' resolves outside the safe directory. "
+            f"Files are restricted to {SAFE_FILE_DIR}"
+        )
+    return resolved
+
 logging.basicConfig(
     level=logging.INFO,
     stream=sys.stderr,
@@ -1325,6 +1339,7 @@ class SauceLabsAgent:
                  400	Bad Request.
                  404	Not found.
         """
+        file_path = _validate_path(file_path)
         if not os.path.exists(file_path):
             raise ValueError(f"File not found: {file_path}")
 

--- a/src/sauce_api_mcp/rdc_dynamic.py
+++ b/src/sauce_api_mcp/rdc_dynamic.py
@@ -21,6 +21,8 @@ import yaml
 from fastmcp.server.openapi import FastMCPOpenAPI, MCPType
 from fastmcp.utilities.openapi import HTTPRoute
 
+from .shared.file_utils import validate_path
+
 logging.basicConfig(
     level=logging.INFO,
     stream=sys.stderr,
@@ -44,25 +46,6 @@ EXCLUDED_PATHS = {
     "/sessions/{sessionId}/device/takeScreenshot",
     "/sessions/{sessionId}/device/pullFile",
 }
-
-# Safe directory for file operations (push/pull)
-SAFE_FILE_DIR = os.path.join(os.path.expanduser("~"), ".sauce-mcp", "files")
-
-
-def _validate_path(file_path: str) -> str:
-    """Validate that a file path resolves within SAFE_FILE_DIR.
-
-    Returns the resolved absolute path if safe, raises ValueError otherwise.
-    """
-    os.makedirs(SAFE_FILE_DIR, exist_ok=True)
-    resolved = os.path.realpath(os.path.join(SAFE_FILE_DIR, os.path.basename(file_path)))
-    if not resolved.startswith(os.path.realpath(SAFE_FILE_DIR)):
-        raise ValueError(
-            f"Path '{file_path}' resolves outside the safe directory. "
-            f"Files are restricted to {SAFE_FILE_DIR}"
-        )
-    return resolved
-
 
 SPEC_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".sauce-mcp")
 SPEC_CACHE_FILE = os.path.join(SPEC_CACHE_DIR, "rdc-access-api-spec.yaml")
@@ -284,7 +267,7 @@ def create_server(
         :param device_path: Optional target path on the device.
         """
         try:
-            safe_path = _validate_path(local_file_path)
+            safe_path = validate_path(local_file_path)
         except ValueError as e:
             return {"error": str(e)}
 
@@ -347,7 +330,7 @@ def create_server(
             Defaults to the filename in ~/.sauce-mcp/files/.
         """
         try:
-            safe_path = _validate_path(
+            safe_path = validate_path(
                 local_save_path if local_save_path else device_file_path
             )
         except ValueError as e:

--- a/src/sauce_api_mcp/shared/file_utils.py
+++ b/src/sauce_api_mcp/shared/file_utils.py
@@ -1,0 +1,15 @@
+import os
+
+SAFE_FILE_DIR = os.path.join(os.path.expanduser("~"), ".sauce-mcp", "files")
+
+
+def validate_path(file_path: str) -> str:
+    """Validate that a file path resolves within SAFE_FILE_DIR."""
+    os.makedirs(SAFE_FILE_DIR, exist_ok=True)
+    resolved = os.path.realpath(os.path.join(SAFE_FILE_DIR, os.path.basename(file_path)))
+    if not resolved.startswith(os.path.realpath(SAFE_FILE_DIR)):
+        raise ValueError(
+            f"Path '{file_path}' resolves outside the safe directory. "
+            f"Files are restricted to {SAFE_FILE_DIR}"
+        )
+    return resolved

--- a/tests/test_rdc_dynamic_e2e.py
+++ b/tests/test_rdc_dynamic_e2e.py
@@ -296,10 +296,11 @@ class TestToolGeneration:
         """
         tools = await compat_get_tools(offline_server)
         expected = {
-            "listDevices", "listDeviceStatus", "createSession", "getSession",
+            "listDevices", "listDeviceStatus", "createSession",
             "deleteSession", "listSessions", "executeShellCommand", "launchApp",
             "openUrl", "installApp", "proxy_http", "listAppiumVersions",
             "startAppiumServer", "listAppInstallations", "uninstallApp",
+            "waitForAppInstallation",
             "listFiles", "removeFile", "statFile",
             "startNetworkCapture", "stopNetworkCapture",
             "setNetworkConditions", "resetNetworkConditions",

--- a/tests/test_rdc_dynamic_e2e.py
+++ b/tests/test_rdc_dynamic_e2e.py
@@ -938,16 +938,16 @@ class TestProductionCodeIssues:
 
     def test_validate_path_rejects_traversal(self):
         """Path traversal attempts are coerced inside SAFE_FILE_DIR via basename strip."""
-        from sauce_api_mcp.rdc_dynamic import _validate_path, SAFE_FILE_DIR
-        resolved = _validate_path("../../etc/passwd")
+        from sauce_api_mcp.shared.file_utils import validate_path, SAFE_FILE_DIR
+        resolved = validate_path("../../etc/passwd")
         assert resolved.startswith(os.path.realpath(SAFE_FILE_DIR))
         assert resolved.endswith("passwd")
         assert "/etc/passwd" not in resolved
 
     def test_validate_path_accepts_plain_filename(self):
         """Plain filenames resolve to SAFE_FILE_DIR/<name>."""
-        from sauce_api_mcp.rdc_dynamic import _validate_path, SAFE_FILE_DIR
-        resolved = _validate_path("app.apk")
+        from sauce_api_mcp.shared.file_utils import validate_path, SAFE_FILE_DIR
+        resolved = validate_path("app.apk")
         assert resolved == os.path.realpath(os.path.join(SAFE_FILE_DIR, "app.apk"))
 
     @pytest.mark.asyncio

--- a/tests/test_rdc_dynamic_e2e.py
+++ b/tests/test_rdc_dynamic_e2e.py
@@ -250,11 +250,14 @@ class TestToolGeneration:
 
     @pytest.mark.asyncio
     async def test_total_tool_count(self, offline_server):
-        """Server should have 31 tools (27 auto + 4 manual).
+        """Server should have 31 tools (24 auto + 7 manual).
 
-        The 4 manual tools are push_file_to_device, pull_file_from_device,
-        take_screenshot, and proxy_http. proxy_http replaces six
-        method-specific auto-generated tools (proxyGet/Post/...).
+        The 7 manual tools are createSession, installApp,
+        waitForAppInstallation, push_file_to_device,
+        pull_file_from_device, take_screenshot, and proxy_http.
+        proxy_http replaces six method-specific auto-generated tools
+        (proxyGet/Post/...). createSession, installApp replace their
+        auto-generated counterparts and add waitForAppInstallation.
         """
         tools = await compat_get_tools(offline_server)
         assert len(tools) == 31, (
@@ -273,9 +276,10 @@ class TestToolGeneration:
 
     @pytest.mark.asyncio
     async def test_manual_tools_registered(self, offline_server):
-        """The 4 manual tools should be present."""
+        """The 7 manual tools should be present."""
         tools = await compat_get_tools(offline_server)
         manual_names = {
+            "createSession", "installApp", "waitForAppInstallation",
             "push_file_to_device", "take_screenshot",
             "pull_file_from_device", "proxy_http",
         }
@@ -378,12 +382,12 @@ class TestToolSchemaValidation:
 
     @pytest.mark.asyncio
     async def test_create_session_has_body_params(self, offline_server):
-        """createSession should have device/configuration body params."""
+        """createSession should have os and optional deviceName params."""
         tools = await compat_get_tools(offline_server)
         params = tools["createSession"].parameters
         props = params.get("properties", {})
-        assert "device" in props or "configuration" in props, (
-            f"createSession params missing body fields. Has: {list(props.keys())}"
+        assert "os" in props, (
+            f"createSession params missing 'os'. Has: {list(props.keys())}"
         )
 
     @pytest.mark.asyncio
@@ -482,7 +486,7 @@ class TestRefResolution:
 # ===================================================================
 
 class TestManualTools:
-    """Tests for the 3 manually-registered binary tools."""
+    """Tests for the manually-registered tools."""
 
     @pytest.mark.asyncio
     async def test_manual_tool_parameters(self, offline_server):
@@ -840,7 +844,7 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_empty_spec_only_manual_tools(self):
-        """Server with empty spec should only have the 4 manual tools."""
+        """Server with empty spec should only have the 7 manual tools."""
         minimal_spec = {
             "openapi": "3.0.0",
             "info": {"title": "empty", "version": "0.0.1"},
@@ -848,11 +852,15 @@ class TestErrorHandling:
         }
         server = create_server(minimal_spec, "key", "user", "US_WEST")
         tools = await compat_get_tools(server)
-        assert len(tools) == 4, (
-            f"Expected 4 manual tools, got {len(tools)}: {sorted(tools.keys())}"
+        manual_names = {
+            "createSession", "installApp", "waitForAppInstallation",
+            "push_file_to_device", "pull_file_from_device",
+            "take_screenshot", "proxy_http",
+        }
+        assert len(tools) == len(manual_names), (
+            f"Expected {len(manual_names)} manual tools, got {len(tools)}: {sorted(tools.keys())}"
         )
-        for name in ("push_file_to_device", "pull_file_from_device",
-                     "take_screenshot", "proxy_http"):
+        for name in manual_names:
             assert name in tools, f"Manual tool '{name}' missing from {sorted(tools.keys())}"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes a path traversal vulnerability in `upload_file_to_storage` where arbitrary file paths (e.g., `/etc/passwd`, `~/.ssh/id_rsa`) could be read and uploaded to Sauce Storage
- Adds `validate_path()` to restrict file operations to `~/.sauce-mcp/files/`, matching the existing pattern in `rdc_dynamic.py`
- Extracts `_validate_path` and `SAFE_FILE_DIR` from `rdc_dynamic.py` into a shared module (`shared/file_utils.py`) so both `main.py` and `rdc_dynamic.py` reuse the same validation logic without duplication

## Test plan
- [ ] Verify uploading a file from `~/.sauce-mcp/files/` works as expected
- [ ] Verify absolute paths outside the safe directory are rejected with `ValueError`
- [ ] Verify paths with `..` traversal are rejected