### PR TITLE
Replace autogenerated app installation tool

### DIFF
--- a/src/sauce_api_mcp/rdc_dynamic.py
+++ b/src/sauce_api_mcp/rdc_dynamic.py
@@ -4,11 +4,21 @@ Dynamic OpenAPI-driven MCP server for Sauce Labs RDC v2 API.
 Auto-generates MCP tools from the official OpenAPI spec at startup using
 FastMCPOpenAPI, so the tool set is always up-to-date without code changes.
 
-A few endpoints are excluded from auto-generation (see EXCLUDED_PATHS) and
-hand-written instead:
+A few endpoints are excluded from auto-generation (see EXCLUDED_PATHS and
+EXCLUDED_OPERATION_IDS) and hand-written instead:
   - pushFile / takeScreenshot / pullFile: binary/multipart payloads.
   - proxy/http/...: collapsed into a single `proxy_http` tool that takes
     the HTTP verb as a parameter, instead of six separate tools.
+  - POST /sessions and GET /sessions/{sessionId}: replaced by a single
+    `createSession` tool that creates the session and polls until the
+    device is ready, so callers don't have to drive the polling loop.
+  - installApp: replaced by a pair of tools (`installApp` +
+    `waitForAppInstallation`). `installApp` starts the install and returns
+    the installation id; `waitForAppInstallation` polls
+    `listAppInstallations` for up to 55s and tells the caller to call it
+    again if the install is still pending. App installs can take longer
+    than the MCP client's ~60s tool-call ceiling, which is why the wait
+    step is a separately callable tool rather than a single blocking call.
 """
 
 import asyncio
@@ -61,10 +71,14 @@ EXCLUDED_PATHS = {
 # Operation IDs excluded from auto-generation. Used for endpoints where we want
 # to suppress a specific HTTP method on a path while keeping others (e.g. we
 # hand-roll POST /sessions and GET /sessions/{sessionId} but keep listSessions
-# and deleteSession).
+# and deleteSession), and for endpoints whose auto-generated shape we want to
+# replace with a richer hand-written version (e.g. installApp, which we wrap
+# with a companion waitForAppInstallation tool so callers don't have to drive
+# the polling loop themselves).
 EXCLUDED_OPERATION_IDS = {
     "createSession",
     "getSession",
+    "installApp",
 }
 
 # Session polling configuration for the hand-written create_session tool.
@@ -79,6 +93,19 @@ EXCLUDED_OPERATION_IDS = {
 SESSION_POLL_INTERVAL_SECONDS = 2.0
 SESSION_POLL_TIMEOUT_SECONDS = 55.0
 SESSION_PENDING_STATES = {"PENDING", "CREATING"}
+
+# App installation polling configuration for the hand-written
+# waitForAppInstallation tool. The backend reports installation progress via
+# listAppInstallations with a per-installation ``status`` that starts at
+# PENDING and transitions to FINISHED, LAUNCHING, or ERROR. We poll until the
+# status leaves PENDING or the per-call timeout elapses. Same 55s cap as
+# session polling: an app install can legitimately take longer than a single
+# MCP tool call, so when we hit the deadline we hand control back to the LLM
+# with guidance to call the tool again rather than blocking past the client's
+# ~60s ceiling.
+APP_INSTALL_POLL_INTERVAL_SECONDS = 2.0
+APP_INSTALL_POLL_TIMEOUT_SECONDS = 55.0
+APP_INSTALL_PENDING_STATES = {"PENDING"}
 
 # Safe directory for file operations (push/pull)
 SAFE_FILE_DIR = os.path.join(os.path.expanduser("~"), ".sauce-mcp", "files")
@@ -505,6 +532,271 @@ def create_server(
             }
 
         return last_session
+
+    @server.tool()
+    async def installApp(
+        sessionId: str,
+        app: str,
+        enableInstrumentation: bool = True,
+        launchAfterInstall: Optional[bool] = None,
+        features: Optional[Dict[str, bool]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Start installing an app on the device in a session, optionally
+        launching it once the install completes.
+
+        This kicks off the install asynchronously on the backend and returns
+        as soon as Sauce Labs has accepted the request. Installation itself
+        can easily take longer than a single MCP tool call — sometimes more
+        than a minute — so this tool does NOT wait for the install to
+        finish. Instead it returns the ``installationId`` and a pointer to
+        the companion ``waitForAppInstallation`` tool, which polls for
+        progress in bounded chunks.
+
+        **Preferred way to install-and-launch.** If the user asks to
+        install and then launch the app ("install and open it", "install
+        and run it", "install and launch", "install this build and start
+        it up", etc.), call THIS tool with ``launchAfterInstall=True``.
+        Do NOT install first and then call the ``launchApp`` tool as a
+        second step — the backend launches the app as part of the install
+        flow when you set this flag, which is faster and avoids race
+        conditions between install completion and launch. Only fall back
+        to ``launchApp`` when the user wants to launch an app that is
+        already installed, or re-launch it after it was closed.
+
+        Typical flow:
+
+        1. Call ``installApp`` with the session id and app reference. Set
+           ``launchAfterInstall=True`` if the user wants the app to start
+           running after install.
+        2. If the returned ``status`` is already ``FINISHED``, ``LAUNCHING``,
+           or ``ERROR``, the install resolved synchronously and you're done.
+        3. Otherwise (``status`` is ``PENDING``), call
+           ``waitForAppInstallation`` with the returned ``sessionId`` and
+           ``installationId`` and keep calling it until it returns a
+           non-pending status.
+
+        :param sessionId: The id of the active device session to install
+            the app into.
+        :param app: Reference to the app in Sauce Labs App Storage, e.g.
+            ``"storage:filename=myapp.apk"`` or
+            ``"storage:<uuid>"``. Required.
+        :param enableInstrumentation: Enable app instrumentation (includes
+            app re-signing on iOS). Required for iOS cloud devices and
+            unlocks advanced features (network capture, image injection,
+            biometrics interception, etc.) on both platforms. **Defaults
+            to True and should almost always stay True.** Only pass
+            ``False`` if the user has explicitly asked to disable
+            instrumentation for this app — never flip it off on your own
+            initiative, even if the install fails, because disabling it
+            on iOS will typically break installation outright.
+        :param launchAfterInstall: If ``True``, the app launches
+            automatically once installation completes. Set this to
+            ``True`` whenever the user's request implies they want the
+            app running after install (install-and-launch, install-and-
+            open, install-and-run, etc.) — prefer this over a follow-up
+            ``launchApp`` call. Defaults to ``False`` on the backend when
+            omitted.
+        :param features: Optional per-feature toggles. Accepts any of:
+            ``networkCapture``, ``deviceVitals``, ``imageInjection``,
+            ``biometricsInterception``, ``bypassScreenshotRestriction``,
+            ``errorReporting``. All default to ``False`` on the backend.
+
+        On success returns a dict with at least ``installationId``,
+        ``status``, ``app``, and ``sessionId`` (the latter echoed so the
+        caller has everything needed to call ``waitForAppInstallation``).
+        When ``status`` is ``PENDING``, ``next_action`` points at the wait
+        tool. On failure returns a dict with an ``error`` key.
+        """
+        # Always include enableInstrumentation on the wire so our tool-side
+        # default (True) wins over any backend default drift. The LLM can
+        # still override it to False, but only when the user explicitly
+        # asks — see the docstring above.
+        payload: Dict[str, Any] = {
+            "app": app,
+            "enableInstrumentation": enableInstrumentation,
+        }
+        if launchAfterInstall is not None:
+            payload["launchAfterInstall"] = launchAfterInstall
+        if features:
+            payload["features"] = features
+
+        response = await client.post(
+            f"sessions/{sessionId}/device/installApp",
+            json=payload,
+        )
+        if response.status_code >= 400:
+            return {
+                "error": f"Install app failed: {response.status_code}",
+                "sessionId": sessionId,
+                "details": _safe_json(response),
+            }
+
+        installation = response.json() if response.content else {}
+        installation_id = installation.get("installationId")
+        status = installation.get("status")
+
+        result: Dict[str, Any] = {
+            "sessionId": sessionId,
+            **installation,
+        }
+
+        if status in APP_INSTALL_PENDING_STATES and installation_id:
+            result["next_action"] = {
+                "tool": "waitForAppInstallation",
+                "arguments": {
+                    "sessionId": sessionId,
+                    "installationId": installation_id,
+                },
+                "message": (
+                    "Installation is still PENDING. Call "
+                    "waitForAppInstallation with the sessionId and "
+                    "installationId above to wait for it to finish. "
+                    "App installs can take longer than 60 seconds, so "
+                    "waitForAppInstallation may ask you to call it again "
+                    "— keep calling until status is no longer PENDING."
+                ),
+            }
+
+        return result
+
+    @server.tool()
+    async def waitForAppInstallation(
+        sessionId: str,
+        installationId: str,
+    ) -> Dict[str, Any]:
+        """
+        Poll an in-progress app installation until it leaves the PENDING
+        state, or return a "call me again" hint if the per-call budget
+        runs out.
+
+        Use this after ``installApp`` returns a PENDING status. This tool
+        polls ``listAppInstallations`` on the session every couple of
+        seconds looking for the installation with the given
+        ``installationId``. It returns as soon as that installation's
+        ``status`` transitions to ``FINISHED``, ``LAUNCHING``, or
+        ``ERROR``. If the budget (55s — short of the MCP client's ~60s
+        tool-call ceiling) elapses while the status is still ``PENDING``,
+        the tool returns with ``status: "PENDING"`` and a ``next_action``
+        pointing back at itself; when you see that, call
+        ``waitForAppInstallation`` again with the same arguments. App
+        installations can legitimately take several minutes, so multiple
+        iterations are expected for large apps.
+
+        :param sessionId: The id of the device session that owns the
+            installation.
+        :param installationId: The installation id returned by
+            ``installApp``.
+
+        On completion returns the full installation record (at minimum
+        ``installationId``, ``app``, ``status``) plus ``sessionId``.
+        When status is ``ERROR`` the ``error`` key is also set so the
+        caller can surface the failure directly. On timeout returns the
+        last observed installation record with ``status: "PENDING"`` and
+        a ``next_action`` instructing the LLM to call this tool again.
+        On API failure returns a dict with an ``error`` key.
+        """
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + APP_INSTALL_POLL_TIMEOUT_SECONDS
+        last_installation: Optional[Dict[str, Any]] = None
+        last_status: Optional[str] = "PENDING"
+
+        # Poll until status leaves PENDING or we run out of time. We check
+        # the status AFTER the request so we always observe at least one
+        # fresh snapshot — useful if the install completed between the
+        # caller's previous call and now.
+        while True:
+            response = await client.post(
+                f"sessions/{sessionId}/device/listAppInstallations",
+            )
+            if response.status_code >= 400:
+                return {
+                    "error": (
+                        f"Listing app installations failed: "
+                        f"{response.status_code}"
+                    ),
+                    "sessionId": sessionId,
+                    "installationId": installationId,
+                    "details": _safe_json(response),
+                }
+
+            body = response.json() if response.content else {}
+            installations = body.get("appInstallations") or []
+            match = next(
+                (
+                    item
+                    for item in installations
+                    if item.get("installationId") == installationId
+                ),
+                None,
+            )
+
+            if match is None:
+                return {
+                    "error": (
+                        f"Installation {installationId} not found for "
+                        f"session {sessionId}. It may have been cleaned "
+                        "up by the backend, or the id is wrong."
+                    ),
+                    "sessionId": sessionId,
+                    "installationId": installationId,
+                }
+
+            last_installation = match
+            last_status = match.get("status")
+
+            if last_status not in APP_INSTALL_PENDING_STATES:
+                break
+
+            if loop.time() >= deadline:
+                # Ran out of budget for this call. Hand control back to
+                # the LLM with a directive to call us again — the install
+                # is still progressing on the backend, we just can't hold
+                # the MCP channel open any longer.
+                return {
+                    "sessionId": sessionId,
+                    "installationId": installationId,
+                    **(last_installation or {}),
+                    "status": last_status or "PENDING",
+                    "timeoutSeconds": int(APP_INSTALL_POLL_TIMEOUT_SECONDS),
+                    "next_action": {
+                        "tool": "waitForAppInstallation",
+                        "arguments": {
+                            "sessionId": sessionId,
+                            "installationId": installationId,
+                        },
+                        "message": (
+                            "Installation is still PENDING after "
+                            f"{int(APP_INSTALL_POLL_TIMEOUT_SECONDS)}s. "
+                            "Call waitForAppInstallation again with the "
+                            "same sessionId and installationId. Keep "
+                            "calling until status is no longer PENDING."
+                        ),
+                    },
+                }
+
+            await asyncio.sleep(APP_INSTALL_POLL_INTERVAL_SECONDS)
+
+        result: Dict[str, Any] = {
+            "sessionId": sessionId,
+            **(last_installation or {}),
+        }
+
+        if last_status == "ERROR":
+            # Surface a top-level ``error`` so the caller doesn't have to
+            # introspect status to realize the install failed. Preserve
+            # whatever the backend reported under ``details``.
+            error_detail = (
+                (last_installation or {}).get("error")
+                or (last_installation or {}).get("detail")
+                or (last_installation or {}).get("message")
+                or "App installation failed. See details for the backend response."
+            )
+            result["error"] = (
+                f"Installation {installationId} failed: {error_detail}"
+            )
+
+        return result
 
     @server.tool()
     async def push_file_to_device(

--- a/tests/test_rdc_dynamic_install_app.py
+++ b/tests/test_rdc_dynamic_install_app.py
@@ -1,0 +1,532 @@
+"""
+Tests for the hand-written ``installApp`` and ``waitForAppInstallation``
+tools in ``sauce_api_mcp.rdc_dynamic``.
+
+The pair replaces the auto-generated ``installApp`` tool so callers don't
+have to drive the ``listAppInstallations`` poll loop themselves. Scenarios
+covered:
+
+1. ``installApp`` happy path (PENDING) returns the installation id plus a
+   ``next_action`` pointing at ``waitForAppInstallation``.
+2. ``installApp`` where the install resolves synchronously to FINISHED —
+   no ``next_action`` should be set.
+3. ``installApp`` where the backend POST fails — error surfaces with
+   details, no ``next_action``.
+4. ``waitForAppInstallation`` happy path where the status transitions
+   PENDING → FINISHED across polls.
+5. ``waitForAppInstallation`` budget exhausted while still PENDING —
+   must return ``next_action`` asking the LLM to call the tool again.
+6. ``waitForAppInstallation`` ERROR state surfaces a top-level ``error``.
+7. ``waitForAppInstallation`` when the installation id isn't in the
+   backend's list — returns an error rather than looping forever.
+"""
+
+from __future__ import annotations
+
+import json as json_mod
+from typing import Any, Callable, Dict, List
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from sauce_api_mcp import rdc_dynamic
+from sauce_api_mcp.rdc_dynamic import create_server
+
+
+MINIMAL_SPEC: Dict[str, Any] = {
+    "openapi": "3.0.0",
+    "info": {"title": "test", "version": "0.0.1"},
+    "paths": {},
+}
+
+
+def _build_server_with_mock_transport(
+    handler: Callable[[httpx.Request], httpx.Response],
+):
+    """Create an RDC server and swap its httpx client transport for a mock.
+
+    Returns ``(server, captured_requests)``. Handler runs for every outbound
+    request; captured requests are recorded in order for post-hoc asserts.
+    """
+    captured_client: List[httpx.AsyncClient] = []
+    original_init = httpx.AsyncClient.__init__
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        captured_client.append(self)
+
+    with patch.object(httpx.AsyncClient, "__init__", patched_init):
+        server = create_server(
+            spec=MINIMAL_SPEC,
+            access_key="fake_key",
+            username="alice",
+        )
+
+    assert captured_client, "create_server did not instantiate an httpx client"
+    client = captured_client[0]
+
+    captured_requests: List[httpx.Request] = []
+
+    async def wrapper(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return handler(request)
+
+    client._transport = httpx.MockTransport(wrapper)
+    return server, captured_requests
+
+
+async def _call_install_app(server, **kwargs) -> Any:
+    tool = await server.get_tool("installApp")
+    return await tool.fn(**kwargs)
+
+
+async def _call_wait_for_install(server, **kwargs) -> Any:
+    tool = await server.get_tool("waitForAppInstallation")
+    return await tool.fn(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """Keep tests fast — skip the real poll interval."""
+    async def _instant(_delay):
+        return None
+
+    with patch.object(rdc_dynamic.asyncio, "sleep", _instant):
+        yield
+
+
+class TestInstallAppTool:
+    @pytest.mark.asyncio
+    async def test_pending_response_includes_next_action(self):
+        """A PENDING install must direct the LLM to waitForAppInstallation."""
+        session_id = "sess-123"
+        installation_id = "install-abc"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path.endswith(
+                f"/sessions/{session_id}/device/installApp"
+            )
+            return httpx.Response(
+                200,
+                json={
+                    "installationId": installation_id,
+                    "app": "storage:uuid-abc",
+                    "status": "PENDING",
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        result = await _call_install_app(
+            server,
+            sessionId=session_id,
+            app="storage:uuid-abc",
+            enableInstrumentation=True,
+            launchAfterInstall=False,
+            features={"networkCapture": True},
+        )
+
+        assert result["installationId"] == installation_id
+        assert result["status"] == "PENDING"
+        assert result["sessionId"] == session_id
+        assert result["next_action"]["tool"] == "waitForAppInstallation"
+        assert result["next_action"]["arguments"] == {
+            "sessionId": session_id,
+            "installationId": installation_id,
+        }
+        # POST body should carry the flags the caller set.
+        body = json_mod.loads(requests[0].content.decode("utf-8"))
+        assert body == {
+            "app": "storage:uuid-abc",
+            "enableInstrumentation": True,
+            "launchAfterInstall": False,
+            "features": {"networkCapture": True},
+        }
+
+    @pytest.mark.asyncio
+    async def test_synchronous_finished_has_no_next_action(self):
+        """If the install resolves synchronously, no polling hint is added."""
+        session_id = "sess-456"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "installationId": "install-done",
+                    "app": "storage:uuid",
+                    "status": "FINISHED",
+                },
+            )
+
+        server, _ = _build_server_with_mock_transport(handler)
+        result = await _call_install_app(
+            server, sessionId=session_id, app="storage:uuid"
+        )
+
+        assert result["status"] == "FINISHED"
+        assert result["sessionId"] == session_id
+        assert "next_action" not in result
+
+    @pytest.mark.asyncio
+    async def test_post_failure_returned_as_error(self):
+        """Backend 4xx should short-circuit with an error and no next_action."""
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={
+                    "type": "about:blank",
+                    "title": "App not found",
+                    "detail": "App storage:nope does not exist.",
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        result = await _call_install_app(
+            server, sessionId="sess-789", app="storage:nope"
+        )
+
+        assert "error" in result
+        assert "400" in result["error"]
+        assert result["sessionId"] == "sess-789"
+        assert result["details"]["title"] == "App not found"
+        assert "next_action" not in result
+        assert [r.method for r in requests] == ["POST"]
+
+    @pytest.mark.asyncio
+    async def test_defaults_enable_instrumentation_true(self):
+        """enableInstrumentation defaults to True and is always on the wire.
+
+        The backend default is also True, but we send it explicitly so the
+        tool's behavior doesn't drift if the backend ever changes its
+        default. launchAfterInstall and features stay absent unless the
+        caller sets them.
+        """
+        session_id = "sess-min"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "installationId": "id-min",
+                    "app": "storage:x",
+                    "status": "FINISHED",
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        await _call_install_app(
+            server, sessionId=session_id, app="storage:x"
+        )
+
+        body = json_mod.loads(requests[0].content.decode("utf-8"))
+        assert body == {
+            "app": "storage:x",
+            "enableInstrumentation": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_explicit_disable_instrumentation_is_respected(self):
+        """Explicit enableInstrumentation=False must still be sent."""
+        session_id = "sess-no-instr"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "installationId": "id-no-instr",
+                    "app": "storage:x",
+                    "status": "FINISHED",
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        await _call_install_app(
+            server,
+            sessionId=session_id,
+            app="storage:x",
+            enableInstrumentation=False,
+        )
+
+        body = json_mod.loads(requests[0].content.decode("utf-8"))
+        assert body == {
+            "app": "storage:x",
+            "enableInstrumentation": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_launch_after_install_flag_is_forwarded(self):
+        """Setting launchAfterInstall=True must reach the backend payload.
+
+        The docstring steers the LLM toward this flag instead of a
+        follow-up launchApp call, so we want to make sure the wire format
+        is correct when it does.
+        """
+        session_id = "sess-launch-after"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "installationId": "id-launch",
+                    "app": "storage:x",
+                    "status": "PENDING",
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        await _call_install_app(
+            server,
+            sessionId=session_id,
+            app="storage:x",
+            launchAfterInstall=True,
+        )
+
+        body = json_mod.loads(requests[0].content.decode("utf-8"))
+        assert body == {
+            "app": "storage:x",
+            "enableInstrumentation": True,
+            "launchAfterInstall": True,
+        }
+
+
+class TestWaitForAppInstallationTool:
+    @pytest.mark.asyncio
+    async def test_pending_then_finished(self):
+        """Poll transitions PENDING → FINISHED and returns the final record."""
+        session_id = "sess-wait-1"
+        installation_id = "install-wait-1"
+        statuses = iter(["PENDING", "FINISHED"])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path.endswith(
+                f"/sessions/{session_id}/device/listAppInstallations"
+            )
+            status = next(statuses)
+            return httpx.Response(
+                200,
+                json={
+                    "appInstallations": [
+                        {
+                            "installationId": installation_id,
+                            "app": "storage:uuid",
+                            "status": status,
+                        },
+                        # An unrelated installation in the same session; the
+                        # tool must pick the one with the matching id.
+                        {
+                            "installationId": "other-install",
+                            "app": "storage:other",
+                            "status": "FINISHED",
+                        },
+                    ]
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        result = await _call_wait_for_install(
+            server,
+            sessionId=session_id,
+            installationId=installation_id,
+        )
+
+        assert result["installationId"] == installation_id
+        assert result["status"] == "FINISHED"
+        assert result["sessionId"] == session_id
+        assert "next_action" not in result
+        assert "error" not in result
+        # One poll saw PENDING, the next saw FINISHED.
+        assert len(requests) == 2
+
+    @pytest.mark.asyncio
+    async def test_launching_status_is_terminal(self):
+        """LAUNCHING counts as "done enough" — don't keep polling."""
+        session_id = "sess-launch"
+        installation_id = "install-launch"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "appInstallations": [
+                        {
+                            "installationId": installation_id,
+                            "app": "storage:uuid",
+                            "status": "LAUNCHING",
+                        }
+                    ]
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        result = await _call_wait_for_install(
+            server,
+            sessionId=session_id,
+            installationId=installation_id,
+        )
+
+        assert result["status"] == "LAUNCHING"
+        assert "next_action" not in result
+        assert len(requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_next_action_call_again(self):
+        """Budget exhausted while PENDING must hand control back to the LLM."""
+        session_id = "sess-timeout"
+        installation_id = "install-timeout"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "appInstallations": [
+                        {
+                            "installationId": installation_id,
+                            "app": "storage:uuid",
+                            "status": "PENDING",
+                        }
+                    ]
+                },
+            )
+
+        server, _ = _build_server_with_mock_transport(handler)
+
+        # asyncio.sleep is already no-op'd; zero the deadline too so the
+        # deadline branch fires after the first observation.
+        with patch.object(
+            rdc_dynamic, "APP_INSTALL_POLL_TIMEOUT_SECONDS", 0.0
+        ):
+            result = await _call_wait_for_install(
+                server,
+                sessionId=session_id,
+                installationId=installation_id,
+            )
+
+        assert result["status"] == "PENDING"
+        assert result["sessionId"] == session_id
+        assert result["installationId"] == installation_id
+        assert result["next_action"]["tool"] == "waitForAppInstallation"
+        assert result["next_action"]["arguments"] == {
+            "sessionId": session_id,
+            "installationId": installation_id,
+        }
+        assert "call" in result["next_action"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_error_status_surfaces_top_level_error(self):
+        """ERROR status must set a top-level ``error`` for the caller."""
+        session_id = "sess-err"
+        installation_id = "install-err"
+        backend_detail = "APK signature verification failed."
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "appInstallations": [
+                        {
+                            "installationId": installation_id,
+                            "app": "storage:uuid",
+                            "status": "ERROR",
+                            "error": backend_detail,
+                        }
+                    ]
+                },
+            )
+
+        server, _ = _build_server_with_mock_transport(handler)
+        result = await _call_wait_for_install(
+            server,
+            sessionId=session_id,
+            installationId=installation_id,
+        )
+
+        assert result["status"] == "ERROR"
+        assert "error" in result
+        assert backend_detail in result["error"]
+        assert result["installationId"] == installation_id
+
+    @pytest.mark.asyncio
+    async def test_installation_not_found_returns_error(self):
+        """If listAppInstallations doesn't include our id, error out."""
+        session_id = "sess-missing"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "appInstallations": [
+                        {
+                            "installationId": "someone-else",
+                            "app": "storage:other",
+                            "status": "FINISHED",
+                        }
+                    ]
+                },
+            )
+
+        server, requests = _build_server_with_mock_transport(handler)
+        result = await _call_wait_for_install(
+            server,
+            sessionId=session_id,
+            installationId="install-ghost",
+        )
+
+        assert "error" in result
+        assert "install-ghost" in result["error"]
+        assert result["sessionId"] == session_id
+        # One lookup, then give up.
+        assert len(requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_failure_returned_as_error(self):
+        """A 5xx on listAppInstallations is surfaced as an error."""
+        session_id = "sess-5xx"
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                500,
+                json={"type": "about:blank", "title": "Internal Server Error"},
+            )
+
+        server, _ = _build_server_with_mock_transport(handler)
+        result = await _call_wait_for_install(
+            server,
+            sessionId=session_id,
+            installationId="any",
+        )
+
+        assert "error" in result
+        assert "500" in result["error"]
+        assert result["sessionId"] == session_id
+
+
+class TestInstallAppToolSchema:
+    @pytest.mark.asyncio
+    async def test_install_app_required_params(self):
+        """``sessionId`` and ``app`` must both be required in the schema."""
+        handler = lambda _r: httpx.Response(200, json={})  # noqa: E731
+        server, _ = _build_server_with_mock_transport(handler)
+
+        tool = await server.get_tool("installApp")
+        schema = tool.parameters
+        required = set(schema.get("required", []))
+        assert {"sessionId", "app"}.issubset(required), (
+            f"sessionId and app must be required, got required={required}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_app_installation_required_params(self):
+        """``sessionId`` and ``installationId`` must both be required."""
+        handler = lambda _r: httpx.Response(200, json={})  # noqa: E731
+        server, _ = _build_server_with_mock_transport(handler)
+
+        tool = await server.get_tool("waitForAppInstallation")
+        schema = tool.parameters
+        required = set(schema.get("required", []))
+        assert {"sessionId", "installationId"}.issubset(required), (
+            "sessionId and installationId must both be required, "
+            f"got required={required}"
+        )


### PR DESCRIPTION
## Description
Currently we register the installApp and listAppInstallations tools dynamically. The listAppInstallations is basically used to poll for the state of an ongoing installation. We want to replace installApp for a tool that polls the listAppInstallations until the app is either installed or the installation process errored.

## Types of Changes

- Refactor/improvements