### PR TITLE
chore: enable dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+


### PR DESCRIPTION
Add a github-actions ecosystem entry to .github/dependabot.yml so Dependabot also tracks workflow action version updates alongside pip dependencies.

