### PR TITLE
ci: automate releases via workflow_dispatch and python-semantic-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    tags: [ 'v*' ]  # Add this to trigger on tags
   pull_request:
     branches: [ main ]
 
@@ -69,53 +67,3 @@ jobs:
         SAUCE_REGION: EU_CENTRAL
       run: python -m pytest -m "slow"
 
-  build:
-    runs-on: ubuntu-latest
-    needs: test-slow
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.12"
-
-    - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-
-    - name: Build package
-      run: python -m build
-
-    - name: Check package
-      run: twine check dist/*
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: dist-files
-        path: dist/
-
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v8
-      with:
-        name: dist-files
-        path: dist/
-
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository-url: https://test.pypi.org/legacy/
-
-    - name: Publish to PyPI
-      if: "!contains(github.ref, 'beta') && !contains(github.ref, 'rc') && !contains(github.ref, 'alpha')"
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,99 @@
-name: Publish to MCP Registry
+name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+        default: patch
+      prerelease_token:
+        description: 'Pre-release token (alpha, beta, rc) — only used when bump_type is prerelease'
+        required: false
+        default: 'rc'
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: read
+      id-token: write   # PyPI trusted publishing + MCP Registry OIDC
+      contents: write   # push version-bump commit and tag
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install python-semantic-release build twine
+
+      - name: Bump version and push tag
+        id: semrel
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ inputs.bump_type }}" == "prerelease" ]; then
+            semantic-release version --as-prerelease --prerelease-token "${{ inputs.prerelease_token }}" --push
+          else
+            semantic-release version --${{ inputs.bump_type }} --push
+          fi
+
+      - name: Build package
+        if: steps.semrel.outputs.released == 'true'
+        run: python -m build
+
+      - name: Check package
+        if: steps.semrel.outputs.released == 'true'
+        run: twine check dist/*
+
+      - name: Publish to TestPyPI (pre-releases)
+        if: |
+          steps.semrel.outputs.released == 'true' &&
+          (contains(steps.semrel.outputs.version, 'alpha') ||
+           contains(steps.semrel.outputs.version, 'beta') ||
+           contains(steps.semrel.outputs.version, 'rc'))
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI (stable releases)
+        if: |
+          steps.semrel.outputs.released == 'true' &&
+          !contains(steps.semrel.outputs.version, 'alpha') &&
+          !contains(steps.semrel.outputs.version, 'beta') &&
+          !contains(steps.semrel.outputs.version, 'rc')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Install MCP Publisher
+        if: steps.semrel.outputs.released == 'true'
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
+        if: steps.semrel.outputs.released == 'true'
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
+        if: steps.semrel.outputs.released == 'true'
         run: ./mcp-publisher publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install MCP Publisher
         if: steps.semrel.outputs.released == 'true'
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v1.0.0/mcp-publisher_1.0.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         if: steps.semrel.outputs.released == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,12 @@ jobs:
             semantic-release version --${{ inputs.bump_type }} --push
           fi
 
+      - name: Create GitHub Release
+        if: steps.semrel.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release publish
+
       - name: Build package
         if: steps.semrel.outputs.released == 'true'
         run: python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ include = ["sauce_api_mcp*"]
 version_toml = ["pyproject.toml:project.version"]
 tag_format = "v{version}"
 commit_message = "chore(release): v{version} [skip ci]"
+build_command = '''jq --arg v "$NEW_VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json'''
 
 [tool.semantic_release.branches.main]
 match = "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,17 @@ include = ["sauce_api_mcp*"]
 
 [tool.setuptools.package-dir]
 "" = "src"
+
+# ---------------------------------------------------------------------------
+# python-semantic-release
+# ---------------------------------------------------------------------------
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+tag_format = "v{version}"
+commit_message = "chore(release): v{version} [skip ci]"
+
+[tool.semantic_release.branches.main]
+match = "main"
+prerelease = false
+

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/saucelabs/sauce-api-mcp",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packages": [
     {
       "registry_type": "pypi",
       "registry_base_url": "https://pypi.org",
       "identifier": "sauce-api-mcp",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
- publish.yml: replaced tag-triggered jobs with a single workflow_dispatch-triggered release job. User picks bump type (patch/minor/major/prerelease) and optional pre-release token (alpha/beta/rc) from the GitHub Actions UI. PSR bumps the version in pyproject.toml, commits, creates and pushes a v* tag, then the workflow builds and publishes to TestPyPI (pre-releases) or PyPI (stable) + MCP Registry.

- build.yml: removed push-tag trigger and build/release jobs that were moved to publish.yml; now runs on pull_request to main only.

- pyproject.toml: added [tool.semantic_release] config pointing PSR at project.version, v{version} tag format, and a [skip ci] commit message to prevent workflow re-triggering.

