### PR TITLE
fix: update server.json schema and guard MCP Registry publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,6 @@ jobs:
            contains(steps.semrel.outputs.version, 'rc'))
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI (stable releases)
@@ -88,18 +87,28 @@ jobs:
           !contains(steps.semrel.outputs.version, 'beta') &&
           !contains(steps.semrel.outputs.version, 'rc')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Install MCP Publisher
-        if: steps.semrel.outputs.released == 'true'
+        if: |
+          steps.semrel.outputs.released == 'true' &&
+          !contains(steps.semrel.outputs.version, 'alpha') &&
+          !contains(steps.semrel.outputs.version, 'beta') &&
+          !contains(steps.semrel.outputs.version, 'rc')
         run: |
           curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
-        if: steps.semrel.outputs.released == 'true'
+        if: |
+          steps.semrel.outputs.released == 'true' &&
+          !contains(steps.semrel.outputs.version, 'alpha') &&
+          !contains(steps.semrel.outputs.version, 'beta') &&
+          !contains(steps.semrel.outputs.version, 'rc')
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        if: steps.semrel.outputs.released == 'true'
+        if: |
+          steps.semrel.outputs.released == 'true' &&
+          !contains(steps.semrel.outputs.version, 'alpha') &&
+          !contains(steps.semrel.outputs.version, 'beta') &&
+          !contains(steps.semrel.outputs.version, 'rc')
         run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,8 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.saucelabs-sample-test-frameworks/sauce-api-mcp",
   "description": "An open-source MCP server that provides LLM access to the Sauce Labs API",
-  "status": "active",
   "repository": {
     "url": "https://github.com/saucelabs/sauce-api-mcp",
     "source": "github"
@@ -10,14 +9,14 @@
   "version": "1.1.0",
   "packages": [
     {
-      "registry_type": "pypi",
-      "registry_base_url": "https://pypi.org",
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
       "identifier": "sauce-api-mcp",
       "version": "1.1.0",
       "transport": {
         "type": "stdio"
       },
-      "environment_variables": [
+      "environmentVariables": [
         {
           "name": "SAUCE_USERNAME",
           "value": "<sauce-user-name>"


### PR DESCRIPTION
server.json:
- Migrate all field names from snake_case to camelCase as required by the 2025-09-16 breaking change in the MCP Registry schema: registry_type → registryType, registry_base_url → registryBaseUrl, environment_variables → environmentVariables
- Remove the "status" field (now registry-managed, removed in 2025-09-29)
- Update $schema URL from 2025-07-09 to 2025-10-17 (current stable) publish.yml:
- Skip MCP Registry steps (Install/Login/Publish) for pre-releases (alpha/beta/rc); only stable releases are published to the registry

