### PR TITLE
fix(registry): correct mcp-name org to io.github.saucelabs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sauce Labs MCP Server
 
-[//]: # (mcp-name: io.github.saucelabs-sample-test-frameworks/sauce-api-mcp)
+[//]: # (mcp-name: io.github.saucelabs/sauce-api-mcp)
 
 A Model Context Protocol (MCP) server that provides comprehensive integration with the Sauce Labs testing platform. This
 package includes two complementary MCP servers enabling AI assistants to interact with Sauce Labs' device cloud, manage


### PR DESCRIPTION
Registry validation requires the literal string
'mcp-name: io.github.saucelabs/sauce-api-mcp' to be present; the previous value used the wrong org (saucelabs-sample-test-frameworks).

